### PR TITLE
Remove Steam WebAPI key

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -114,7 +114,7 @@ const getSteamAPIURL = (inter, method, version, parameters) => {
 	if (!parameters) {
 		parameters = {}
 	}
-	parameters.key = '77B909BDB1214C26615DD2ECF4A4FA21'
+	parameters.key = process.env.STEAM_WEBAPI_KEY || ''
 	return `https://api.steampowered.com/${inter}/${method}/${version}?${querystring.stringify(parameters)}`
 }
 const requestApiLiveGame = server_steam_id => {


### PR DESCRIPTION
Use an environment variable instead of listing it in plain text.

Fixes #10, but don't forget to also revoke the key and update the bot to use the new one.