### PR TITLE
Fix new channels not being able to link accounts

### DIFF
--- a/lib/commands/Moderation.js
+++ b/lib/commands/Moderation.js
@@ -361,6 +361,14 @@ let command = {
 
 /* Adds Steam ID to the channel's list of linked accounts. */
 async function addAccount(username, channel, steamId) {
+	const successMessage = `${username} successfully added ${steamId} to ${channel.name} accounts`
+
+	// If the channel has no linked accounts, create the field.
+	if (!channel.accounts) {
+		await mongoDb().collection('channels').updateOne({ id: channel.id }, { $set: { accounts: [steamId] } })
+		return successMessage
+	}
+
 	/* Check if there are already 10 accounts linked to this channel,
 	 * or if the account has already been linked. */
 	if (channel.accounts.length > 10) {
@@ -373,13 +381,13 @@ async function addAccount(username, channel, steamId) {
 
 	// All good, link the account to the channel.
 	await mongoDb().collection('channels').updateOne({ id: channel.id }, { $addToSet: { accounts: steamId } })
-	return `${username} successfully added ${steamId} to ${channel.name} accounts`
+	return successMessage
 }
 
 /* Removes a Steam ID from the channel's list of linked accounts */
 async function deleteAccount(username, channel, steamId) {
 	// Check that the Steam account is linked to the channel before attempting to remove it.
-	if (!channel.accounts.some(account => account == steamId)) {
+	if (!channel.accounts || !channel.accounts.some(account => account == steamId)) {
 		return Promise.reject(new CustomError(`Account ${steamId} is not linked to ${channel.name}`))
 	}
 


### PR DESCRIPTION
If the `accounts` field doesn't exist on the document, we will create it (containing the Steam ID to be linked).

Fixes #19 